### PR TITLE
CSS module rename & ambiguous date resize

### DIFF
--- a/src/components/inputs/date/DateAmbiguous.vue
+++ b/src/components/inputs/date/DateAmbiguous.vue
@@ -419,29 +419,23 @@ watch(returnDate, () => {
 
 .datePopup {
   position: absolute;
-  max-width: 530px;
+  min-width: 250px;
+  max-width: 350px;
   background: white;
   border: 1px solid $grey;
   border-radius: $rounding;
   top: 100%;
-  left: $h-pad;
-  right: $h-pad;
+  left: 0;
   margin-top: $v-pad;
   padding: $padding;
+  z-index: 9999;
 }
 
 .popupSection {
   display: grid;
   align-items: start;
-
-  @include media-from('lg') {
-    grid-template-columns: 35% 1fr;
-  }
-  @include media-less-than('lg') {
-    padding-bottom: 1em;
-  }
   gap: 1em 2em;
-  padding: $padding;
+  padding: $v-pad $h-pad 1em;
 
   &:not(:last-child) {
     border-bottom: 1px solid $grey;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
 import { visualizer } from 'rollup-plugin-visualizer';
+import crypto from 'crypto';
 
 export default defineConfig({
   plugins: [vue(), visualizer()],
@@ -31,7 +32,21 @@ export default defineConfig({
   },
   css: {
     modules: {
-      generateScopedName: 'zoa__[hash:base64:5]__[local]',
+      generateScopedName: (name, filename, css) => {
+        let componentName;
+        // prefer using the component name, but fall back to hash if that
+        // doesn't work
+        try {
+          componentName = filename.split('/').pop().split('.')[0].toLowerCase();
+        } catch {
+          componentName = crypto
+            .createHash('md5')
+            .update(css)
+            .digest('base64')
+            .substring(0, 5);
+        }
+        return `zoa__${componentName}__${name}`;
+      },
     },
   },
 });


### PR DESCRIPTION
CSS module names are now formatted as: `zoa__[componentname]__[className]` (instead of `zoa__[hash]__[className]`). This is so that the names are more predictable and can be utilised by the application calling the zoa component.

The ambiguous date dropdown/popup is also now smaller and its "large window" layout has been removed.