### PR TITLE
feat: add max-height and scroll to autocomplete options

### DIFF
--- a/src/components/inputs/textbox/AutocompleteTextbox.vue
+++ b/src/components/inputs/textbox/AutocompleteTextbox.vue
@@ -220,6 +220,8 @@ function setOption(text) {
 
 .option {
   padding: $padding;
+  overflow-y: auto;
+  max-height: 12em;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
`12em` is chosen arbitrarily, we may want to make this customisable (e.g. as a "show this many options on screen at once" slot) though it may be challenging to implement and not necessarily worth it.

Closes: #34