### PR TITLE
Improve storybook code examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,7 +4,6 @@ about: Report a bug you've found in this extension
 title: ''
 labels: bug
 assignees: ''
-
 ---
 
 **Description**
@@ -18,6 +17,7 @@ Steps to reproduce the bug.
 
 **Error Log**
 Paste any relevant error logs below:
+
 ```
 <error log here>
 ```
@@ -26,8 +26,9 @@ Paste any relevant error logs below:
 Add screenshots to illustrate the bug if you want.
 
 **Your Setup**
- - Commit/version of this repo:
- - Browser (if relevant): [e.g. chrome, safari]
+
+- Commit/version of this repo:
+- Browser (if relevant): [e.g. chrome, safari]
 
 **Anything Else?**
 ...

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an feature or improvement for this extension
 title: ''
 labels: enhancement
 assignees: ''
-
 ---
 
 **Overview**

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,13 +1,16 @@
 # Support
 
 ## Documentation
+
 - [Our API documentation](https://naturalhistorymuseum.github.io/dataportal-docs)
 
 ## Issues
+
 - [The NHM on Github](https://github.com/NaturalHistoryMuseum)
 - [General issue tracker](https://github.com/NaturalHistoryMuseum/data-portal-issues/issues)
 
 ## Contact Us
+
 - [Gitter](https://gitter.im/nhm-data-portal/lobby)
 - [Email _data@nhm.ac.uk_](mailto:data@nhm.ac.uk)
 - [Twitter](https://twitter.com/nhm_data)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: dist
-          message: "chore: build dist package"
+          message: 'chore: build dist package'

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,18 +28,18 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: dist
-          message: "chore: build dist package"
+          message: 'chore: build dist package'
           push: false
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: CURRENT.md
-          extra_requirements: "cz-nhm"
+          extra_requirements: 'cz-nhm'
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          body_path: "CURRENT.md"
+          body_path: 'CURRENT.md'
           tag_name: v${{ env.REVISION }}
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
       - name: Publish package
         run: npm publish
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,17 +7,17 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: name-tests-test
-        args: [ '--pytest-test-first' ]
+        args: ['--pytest-test-first']
         exclude: ^tests/helpers/
       - id: trailing-whitespace
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.1.0
     hooks:
       - id: commitizen
-        additional_dependencies: [ 'cz-nhm' ]
+        additional_dependencies: ['cz-nhm']
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
-        types_or: [ javascript, vue, less, sass, scss, css ]
-        args: [ '--single-quote' ]
+        types_or: [javascript, vue, less, sass, scss, css]
+        args: ['--single-quote']

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+.idea
+**/node_modules/
+dist/

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,6 +1,9 @@
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Source+Sans+3&display=swap" rel="stylesheet">
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Source+Sans+3&display=swap"
+  rel="stylesheet"
+/>
 <script>
   window.global = window;
 </script>

--- a/README.md
+++ b/README.md
@@ -20,20 +20,20 @@ The components can either be registered globally:
 
 ```javascript
 // main.js
-import {createApp} from 'vue'
-import App from './App.vue'
-import {Zoa} from '@nhm-data/zoa';
+import { createApp } from 'vue';
+import App from './App.vue';
+import { Zoa } from '@nhm-data/zoa';
 import '@nhm-data/zoa/theme';
 
-const app = createApp(App)
-app.use(Zoa)
-app.mount('#app')
+const app = createApp(App);
+app.use(Zoa);
+app.mount('#app');
 ```
 
 ```vue
 <!-- Component.vue -->
 <template>
-  <zoa-button label="Submit"/>
+  <zoa-button label="Submit" />
 </template>
 ```
 
@@ -42,7 +42,7 @@ Or imported manually into individual components:
 ```vue
 <!-- Component.vue -->
 <template>
-  <zoa-button label="Submit"/>
+  <zoa-button label="Submit" />
 </template>
 
 <script setup>
@@ -57,8 +57,16 @@ Inputs (other than the button and toggle button) are used via the `<zoa-input>` 
 
 ```vue
 <template>
-  <zoa-input zoa-type="checkbox" label="Checkbox" :options="{ name: 'chkbox', delay: '200' }"/>
-  <zoa-input zoa-type="textbox" label="Textbox" :options="{ placeholder: 'this is a placeholder' }"/>
+  <zoa-input
+    zoa-type="checkbox"
+    label="Checkbox"
+    :options="{ name: 'chkbox', delay: '200' }"
+  />
+  <zoa-input
+    zoa-type="textbox"
+    label="Textbox"
+    :options="{ placeholder: 'this is a placeholder' }"
+  />
 </template>
 
 <script setup>

--- a/src/components/buttons/button/Button.stories.js
+++ b/src/components/buttons/button/Button.stories.js
@@ -1,4 +1,5 @@
 import ZoaButton from './Button.vue';
+import { renderSetup, htmlArgs } from '../../utils/stories.js';
 
 const template = `
 <zoa-button :class="rootClass"
@@ -43,27 +44,63 @@ const Base = {
   render: (args) => ({
     components: { ZoaButton },
     setup() {
-      args['rootClass'] = args.class;
-      delete args.class;
-      return args;
+      return renderSetup(args);
     },
     template,
   }),
 };
 
+// this is the main example; if we don't have this then the first variant is
+// used
+export const Default = {
+  ...Base,
+  tags: ['!dev', '!autodocs'], // hides it from the sidebar and variant section
+};
+
+// VARIANTS =====
+const normalArgs = {
+  kind: 'normal',
+};
 export const Normal = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'normal',
+  args: normalArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-button ${htmlArgs(normalArgs)}/>`,
+      },
+    },
   },
 };
 
+const primaryArgs = {
+  kind: 'primary',
+  label: 'Special Button',
+};
 export const Primary = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'primary',
-    label: 'Special Button',
+  args: primaryArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-button ${htmlArgs(primaryArgs)}/>`,
+      },
+    },
+  },
+};
+
+const altArgs = {
+  kind: 'alt',
+  label: 'Different Button',
+};
+export const Alt = {
+  ...Base,
+  args: altArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-button ${htmlArgs(altArgs)}/>`,
+      },
+    },
   },
 };

--- a/src/components/buttons/button/Button.stories.js
+++ b/src/components/buttons/button/Button.stories.js
@@ -1,5 +1,12 @@
 import ZoaButton from './Button.vue';
 
+const template = `
+<zoa-button :class="rootClass"
+            :label="label"
+            :kind="kind"
+            :size="size"/>
+`;
+
 const meta = {
   component: ZoaButton,
   title: 'Components/Buttons/Button',
@@ -17,6 +24,9 @@ const meta = {
     docs: {
       description: {
         component: 'A button.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -37,18 +47,14 @@ const Base = {
       delete args.class;
       return args;
     },
-    template: `
-      <zoa-button :class="rootClass"
-                  :label="label"
-                  :kind="kind"
-                  :size="size"/>
-        `,
+    template,
   }),
 };
 
 export const Normal = {
   ...Base,
   args: {
+    ...Base.args,
     kind: 'normal',
   },
 };
@@ -56,6 +62,7 @@ export const Normal = {
 export const Primary = {
   ...Base,
   args: {
+    ...Base.args,
     kind: 'primary',
     label: 'Special Button',
   },

--- a/src/components/buttons/tabs/Tabs.stories.js
+++ b/src/components/buttons/tabs/Tabs.stories.js
@@ -1,5 +1,16 @@
 import ZoaTabs from './Tabs.vue';
 
+const template = `
+<zoa-tabs :class="rootClass"
+          :delay="delay"
+          :active-position="activePosition"
+          :initial-value="initialValue"
+          :kind="kind"
+          :options="options"
+          :size="size"
+/>
+`;
+
 const meta = {
   component: ZoaTabs,
   title: 'Components/Buttons/Tabs',
@@ -32,6 +43,9 @@ const meta = {
       description: {
         component: 'A set of radio buttons displayed as tabs.',
       },
+      source: {
+        code: template,
+      },
     },
   },
 };
@@ -60,16 +74,7 @@ const Base = {
       delete args.class;
       return args;
     },
-    template: `
-          <zoa-tabs :class="rootClass"
-                    :delay="delay"
-                    :active-position="activePosition"
-                    :initial-value="initialValue"
-                    :kind="kind"
-                    :options="options"
-                    :size="size"
-          />
-        `,
+    template,
   }),
 };
 

--- a/src/components/buttons/tabs/Tabs.stories.js
+++ b/src/components/buttons/tabs/Tabs.stories.js
@@ -1,4 +1,5 @@
 import ZoaTabs from './Tabs.vue';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-tabs :class="rootClass"
@@ -70,9 +71,7 @@ const Base = {
   render: (args) => ({
     components: { ZoaTabs },
     setup() {
-      args['rootClass'] = args.class;
-      delete args.class;
-      return args;
+      return renderSetup(args);
     },
     template,
   }),

--- a/src/components/buttons/togglebutton/ToggleButton.stories.js
+++ b/src/components/buttons/togglebutton/ToggleButton.stories.js
@@ -1,4 +1,5 @@
 import ZoaToggleButton from './ToggleButton.vue';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-toggle-button :class="rootClass"
@@ -62,9 +63,7 @@ const Base = {
   render: (args) => ({
     components: { ZoaToggleButton },
     setup() {
-      args['rootClass'] = args.class;
-      delete args.class;
-      return args;
+      return renderSetup(args);
     },
     template,
   }),

--- a/src/components/buttons/togglebutton/ToggleButton.stories.js
+++ b/src/components/buttons/togglebutton/ToggleButton.stories.js
@@ -1,5 +1,16 @@
 import ZoaToggleButton from './ToggleButton.vue';
 
+const template = `
+<zoa-toggle-button :class="rootClass"
+                   :delay="delay"
+                   :label="label"
+                   :check-value="checkValue"
+                   :kind="kind"
+                   :name="name"
+                   :size="size"
+/>
+`;
+
 const meta = {
   component: ZoaToggleButton,
   title: 'Components/Buttons/ToggleButton',
@@ -29,6 +40,9 @@ const meta = {
         component:
           "A toggleable button. Only shows its status via colour change, so it's mostly useful for things like opening menus rather than as a part of a form.",
       },
+      source: {
+        code: template,
+      },
     },
   },
 };
@@ -52,16 +66,7 @@ const Base = {
       delete args.class;
       return args;
     },
-    template: `
-          <zoa-toggle-button :class="rootClass"
-                             :delay="delay"
-                             :label="label"
-                             :check-value="checkValue"
-                             :kind="kind"
-                             :name="name"
-                             :size="size"
-          />
-        `,
+    template,
   }),
 };
 

--- a/src/components/dialogs/flash/Flash.stories.js
+++ b/src/components/dialogs/flash/Flash.stories.js
@@ -1,10 +1,11 @@
 import ZoaFlash from './Flash.vue';
+import { renderSetup, htmlArgs } from '../../utils/stories.js';
 
 const template = `
 <zoa-flash :kind="kind"
-           :class="rootClass"
            :header="header"
            :message="message"
+           :class="rootClass"
 />
 `;
 
@@ -33,43 +34,88 @@ const meta = {
 export default meta;
 
 const Base = {
-  args: {},
+  args: {
+    kind: 'info',
+    header: 'Flash dialog header',
+    message:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis at tellus at urna condimentum.',
+    class: '',
+  },
   render: (args) => ({
     components: { ZoaFlash },
     setup() {
-      return { args };
+      return renderSetup(args);
     },
     template,
   }),
 };
 
+// this is the main example; if we don't have this then Info is used
+export const Default = {
+  ...Base,
+  tags: ['!dev', '!autodocs'], // hides it from the sidebar and variant section
+};
+
+// VARIANTS =====
+const infoArgs = {
+  kind: 'info',
+};
 export const Info = {
   ...Base,
-  args: {
-    kind: 'info',
+  args: infoArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-flash ${htmlArgs(infoArgs)}/>`,
+      },
+    },
   },
 };
 
+const warningArgs = {
+  kind: 'warning',
+  header: "Are you sure that's a good idea?",
+};
 export const Warning = {
   ...Base,
-  args: {
-    kind: 'warning',
-    header: "Are you sure that's a good idea?",
+  args: warningArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-flash ${htmlArgs(warningArgs)}/>`,
+      },
+    },
   },
 };
 
+const errorArgs = {
+  kind: 'error',
+  header: 'Oh no! Something went wrong.',
+};
 export const Error = {
   ...Base,
-  args: {
-    kind: 'error',
-    header: 'Oh no! Something went wrong.',
+  args: errorArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-flash ${htmlArgs(errorArgs)}/>`,
+      },
+    },
   },
 };
 
+const successArgs = {
+  kind: 'success',
+  header: 'Congratulations! The thing worked.',
+};
 export const Success = {
   ...Base,
-  args: {
-    kind: 'success',
-    header: 'Congratulations! The thing worked.',
+  args: successArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-flash ${htmlArgs(successArgs)}/>`,
+      },
+    },
   },
 };

--- a/src/components/dialogs/flash/Flash.stories.js
+++ b/src/components/dialogs/flash/Flash.stories.js
@@ -1,5 +1,13 @@
 import ZoaFlash from './Flash.vue';
 
+const template = `
+<zoa-flash :kind="kind"
+           :class="rootClass"
+           :header="header"
+           :message="message"
+/>
+`;
+
 const meta = {
   component: ZoaFlash,
   title: 'Components/Dialogs/Flash',
@@ -15,6 +23,9 @@ const meta = {
         component:
           'A flash dialog for displaying alert messages within the body of the page.',
       },
+      source: {
+        code: template,
+      },
     },
   },
 };
@@ -28,9 +39,7 @@ const Base = {
     setup() {
       return { args };
     },
-    template: `
-          <zoa-flash v-bind="args"/>
-        `,
+    template,
   }),
 };
 

--- a/src/components/dialogs/modal/Modal.stories.js
+++ b/src/components/dialogs/modal/Modal.stories.js
@@ -1,5 +1,9 @@
 import ZoaModal from './Modal.vue';
 
+const template = `
+<zoa-modal v-bind="args"/>
+  `;
+
 const meta = {
   component: ZoaModal,
   title: 'Components/Dialogs/Modal',
@@ -13,6 +17,9 @@ const meta = {
     docs: {
       description: {
         component: 'A modal dialog for displaying pop-up alert messages.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -29,9 +36,7 @@ const Base = {
     setup() {
       return { args };
     },
-    template: `
-      <zoa-modal v-bind="args"/>
-        `,
+    template,
   }),
 };
 

--- a/src/components/dialogs/modal/Modal.stories.js
+++ b/src/components/dialogs/modal/Modal.stories.js
@@ -1,8 +1,14 @@
 import ZoaModal from './Modal.vue';
+import { renderSetup, htmlArgs } from '../../utils/stories.js';
 
 const template = `
-<zoa-modal v-bind="args"/>
-  `;
+<zoa-modal :kind="kind"
+           :header="header"
+           :message="message"
+           :class="rootClass"
+           :button-args="buttonArgs"
+/>
+`;
 
 const meta = {
   component: ZoaModal,
@@ -29,12 +35,17 @@ export default meta;
 
 const Base = {
   args: {
-    message: 'Here is some content that goes in the modal.',
+    kind: 'info',
+    header: 'Modal dialog header',
+    message:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Duis at tellus at urna condimentum.',
+    class: '',
+    buttonArgs: { label: 'Open modal' },
   },
   render: (args) => ({
     components: { ZoaModal },
     setup() {
-      return { args };
+      return renderSetup(args);
     },
     template,
   }),
@@ -42,65 +53,90 @@ const Base = {
 
 export const Default = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'info',
-    header: 'Parameters can be set using properties',
-  },
+  tags: ['!dev', '!autodocs'], // hides it from the sidebar and variant section
 };
 
-export const Slot = {
-  ...Base,
-  args: {
-    kind: 'info',
-  },
-  render: (args) => ({
+const slotTemplate = `
+<zoa-modal>
+  <template v-slot:button>Button label</template>
+  <template v-slot:header>You can also use slots!</template>
+  <span>The default slot defines the modal body.</span>
+</zoa-modal>
+`;
+export const Slots = {
+  render: () => ({
     components: { ZoaModal },
-    setup() {
-      return { args };
-    },
-    template: `
-      <zoa-modal v-bind="args">
-        <template v-slot:button>Button slot</template>
-        <template v-slot:header>Or you can use slots</template>
-        <span>The default slot defines the modal body.</span>
-      </zoa-modal>
-        `,
+    template: slotTemplate,
   }),
+  parameters: {
+    docs: {
+      source: {
+        code: slotTemplate,
+      },
+    },
+  },
 };
 
+// VARIANTS =====
+const infoArgs = {
+  kind: 'info',
+};
 export const Info = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'info',
-    header: 'Here is an informational message.',
+  args: infoArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-modal ${htmlArgs(infoArgs)}/>`,
+      },
+    },
   },
 };
 
+const warningArgs = {
+  kind: 'warning',
+  header: "Are you sure that's a good idea?",
+};
 export const Warning = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'warning',
-    header: "Are you sure that's a good idea?",
+  args: warningArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-modal ${htmlArgs(warningArgs)}/>`,
+      },
+    },
   },
 };
 
+const errorArgs = {
+  kind: 'error',
+  header: 'Oh no! Something went wrong.',
+};
 export const Error = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'error',
-    header: 'Oh no! Something went wrong.',
+  args: errorArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-modal ${htmlArgs(errorArgs)}/>`,
+      },
+    },
   },
 };
 
+const successArgs = {
+  kind: 'success',
+  header: 'Congratulations! The thing worked.',
+};
 export const Success = {
   ...Base,
-  args: {
-    ...Base.args,
-    kind: 'success',
-    header: 'Congratulations! The thing worked.',
+  args: successArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `<zoa-modal ${htmlArgs(successArgs)}/>`,
+      },
+    },
   },
 };

--- a/src/components/inputs/checkbox/Checkbox.stories.js
+++ b/src/components/inputs/checkbox/Checkbox.stories.js
@@ -1,6 +1,7 @@
 import ZoaCheckbox from './Checkbox.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="checkbox"

--- a/src/components/inputs/checkbox/Checkbox.stories.js
+++ b/src/components/inputs/checkbox/Checkbox.stories.js
@@ -2,6 +2,18 @@ import ZoaCheckbox from './Checkbox.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="checkbox"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, name, checkValue}"
+/>
+`;
+
 const meta = {
   component: ZoaCheckbox,
   title: 'Components/Inputs/Checkbox',
@@ -10,6 +22,9 @@ const meta = {
     docs: {
       description: {
         component: 'A single checkbox with an optional label.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -34,17 +49,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="checkbox"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, name, checkValue}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/date/DateAmbiguous.stories.js
+++ b/src/components/inputs/date/DateAmbiguous.stories.js
@@ -1,6 +1,7 @@
 import ZoaDateAmbiguous from './DateAmbiguous.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="date-ambiguous"

--- a/src/components/inputs/date/DateAmbiguous.stories.js
+++ b/src/components/inputs/date/DateAmbiguous.stories.js
@@ -2,6 +2,18 @@ import ZoaDateAmbiguous from './DateAmbiguous.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="date-ambiguous"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, min, max}"
+/>
+`;
+
 const meta = {
   component: ZoaDateAmbiguous,
   title: 'Components/Inputs/Date/Ambiguous Date',
@@ -11,6 +23,9 @@ const meta = {
       description: {
         component:
           'A date picker that allows for missing parts, e.g. just a year, a year and a month, a month and a day, etc.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -36,17 +51,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="date-ambiguous"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, min, max}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/date/DateSimple.stories.js
+++ b/src/components/inputs/date/DateSimple.stories.js
@@ -2,6 +2,18 @@ import ZoaDateSimple from './DateSimple.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="date-simple"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, min, max, step}"
+/>
+`;
+
 const meta = {
   component: ZoaDateSimple,
   title: 'Components/Inputs/Date/Simple Date',
@@ -10,6 +22,9 @@ const meta = {
     docs: {
       description: {
         component: 'A standard date picker.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -36,17 +51,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="date-simple"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, min, max, step}"
-      />
-        `,
+    template,
   }),
 };
 

--- a/src/components/inputs/date/DateSimple.stories.js
+++ b/src/components/inputs/date/DateSimple.stories.js
@@ -1,6 +1,7 @@
 import ZoaDateSimple from './DateSimple.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="date-simple"

--- a/src/components/inputs/dropdown/Dropdown.stories.js
+++ b/src/components/inputs/dropdown/Dropdown.stories.js
@@ -2,6 +2,18 @@ import ZoaDropdown from './Dropdown.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="dropdown"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, options}"
+/>
+`;
+
 const meta = {
   component: ZoaDropdown,
   title: 'Components/Inputs/Select/Dropdown',
@@ -11,6 +23,9 @@ const meta = {
       description: {
         component:
           'A dropdown/select component. Options can be passed in as a mixed list of strings or objects with `label` and `value` keys.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -35,17 +50,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="dropdown"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, options}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/dropdown/Dropdown.stories.js
+++ b/src/components/inputs/dropdown/Dropdown.stories.js
@@ -1,6 +1,7 @@
 import ZoaDropdown from './Dropdown.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="dropdown"

--- a/src/components/inputs/dropdown/DropdownSearch.stories.js
+++ b/src/components/inputs/dropdown/DropdownSearch.stories.js
@@ -1,6 +1,7 @@
 import ZoaDropdownSearch from './DropdownSearch.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="dropdown-search"

--- a/src/components/inputs/dropdown/DropdownSearch.stories.js
+++ b/src/components/inputs/dropdown/DropdownSearch.stories.js
@@ -2,6 +2,18 @@ import ZoaDropdownSearch from './DropdownSearch.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="dropdown-search"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, options, searchDelay, enableSearch, itemHeight}"
+/>
+`;
+
 const meta = {
   component: ZoaDropdownSearch,
   title: 'Components/Inputs/Select/DropdownSearch',
@@ -11,6 +23,9 @@ const meta = {
       description: {
         component:
           'A dropdown/select component allowing searching/filtering the list of potential options. Options can be passed in as a mixed list of strings or objects with `label` and `value` keys. Each option must have a unique value (or label, if not using values).',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -46,17 +61,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="dropdown-search"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, options, searchDelay, enableSearch, itemHeight}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -1,7 +1,8 @@
 import ZoaMultiselect from './Multiselect.vue';
 import { nanoid } from 'nanoid';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="multiselect"

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -3,6 +3,18 @@ import { nanoid } from 'nanoid';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="multiselect"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, options, itemName, itemNamePlural, searchDelay, enableSearch, itemHeight}"
+/>
+`;
+
 const meta = {
   component: ZoaMultiselect,
   title: 'Components/Inputs/Select/Multiselect',
@@ -12,6 +24,9 @@ const meta = {
       description: {
         component:
           'A dropdown/select component allowing selection of multiple options. Options can be passed in as a mixed list of strings or objects with `label`, `value`, and (optionally) `group` keys. Each option must have a unique value (or label, if not using values), even between groups.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -48,17 +63,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="multiselect"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, options, itemName, itemNamePlural, searchDelay, enableSearch, itemHeight}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -77,29 +77,39 @@ const groups = ['root'];
   groups.push(`Group ${i + 1}`);
 });
 
+const manyArgs = {
+  label: 'Many Options',
+  labelPosition: 'above',
+  help: 'An example with a lot of randomly generated options and groups.',
+  options: [...Array(300).keys()].map((i) => {
+    let opt = {
+      value: nanoid(Math.ceil(Math.random() * 100)),
+    };
+    const group = groups[Math.floor(Math.random() * groups.length)];
+    if (group !== 'root') {
+      opt['group'] = group;
+    }
+    return opt;
+  }),
+  itemName: 'datum',
+  itemNamePlural: 'data',
+  enableSearch: true,
+};
 export const Many = {
   ...Base,
-  args: {
-    label: 'Many Options',
-    labelPosition: 'above',
-    help: 'Some example help text.',
-    helpPosition: 'right',
-    delay: 0,
-    placeholder: 'select option',
-    options: [...Array(300).keys()].map((i) => {
-      let opt = {
-        value: nanoid(Math.ceil(Math.random() * 100)),
-      };
-      const group = groups[Math.floor(Math.random() * groups.length)];
-      if (group !== 'root') {
-        opt['group'] = group;
-      }
-      return opt;
-    }),
-    itemName: 'datum',
-    itemNamePlural: 'data',
-    searchDelay: 200,
-    enableSearch: true,
-    itemHeight: 38,
+  args: manyArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<zoa-input zoa-type="multiselect"
+           label="${manyArgs.label}"
+           label-position="${manyArgs.labelPosition}"
+           help="${manyArgs.help}"
+           :options="{options, itemName: '${manyArgs.itemName}', itemNamePlural: '${manyArgs.itemNamePlural}', enableSearch: ${manyArgs.enableSearch}}"
+/>
+        `,
+      },
+    },
   },
 };

--- a/src/components/inputs/empty/Empty.stories.js
+++ b/src/components/inputs/empty/Empty.stories.js
@@ -1,6 +1,20 @@
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="empty"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :grid-class="gridClass"
+>
+  <zoa-input zoa-type="checkbox" label-position="below" label="option 1"/>
+  <zoa-input zoa-type="checkbox" label-position="below" label="option 2"/>
+</zoa-input>
+`;
+
 const meta = {
   component: ZoaInput,
   title: 'Components/Inputs/Empty',
@@ -38,6 +52,9 @@ const meta = {
         component:
           'An empty grid for positioning other inputs under a single label.',
       },
+      source: {
+        code: template,
+      },
     },
   },
 };
@@ -58,19 +75,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="empty"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :grid-class="gridClass"
-      >
-        <zoa-input zoa-type="checkbox" label-position="below" label="option 1"/>
-        <zoa-input zoa-type="checkbox" label-position="below" label="option 2"/>
-      </zoa-input>
-        `,
+    template,
   }),
 };
 

--- a/src/components/inputs/empty/Empty.stories.js
+++ b/src/components/inputs/empty/Empty.stories.js
@@ -1,5 +1,6 @@
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="empty"

--- a/src/components/inputs/number/Number.stories.js
+++ b/src/components/inputs/number/Number.stories.js
@@ -1,6 +1,7 @@
 import ZoaNumber from './Number.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="number"

--- a/src/components/inputs/number/Number.stories.js
+++ b/src/components/inputs/number/Number.stories.js
@@ -2,6 +2,18 @@ import ZoaNumber from './Number.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="number"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, min, max, step}"
+/>
+`;
+
 const meta = {
   component: ZoaNumber,
   title: 'Components/Inputs/Number',
@@ -10,6 +22,9 @@ const meta = {
     docs: {
       description: {
         component: 'A number select component.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -36,17 +51,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="number"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, min, max, step}"
-      />
-        `,
+    template,
   }),
 };
 

--- a/src/components/inputs/radio/Radio.stories.js
+++ b/src/components/inputs/radio/Radio.stories.js
@@ -2,6 +2,18 @@ import ZoaRadio from './Radio.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="radio"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, name, checkValue}"
+/>
+`;
+
 const meta = {
   component: ZoaRadio,
   title: 'Components/Inputs/Radio',
@@ -10,6 +22,9 @@ const meta = {
     docs: {
       description: {
         component: 'A single radio button with an optional label.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -34,17 +49,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="radio"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, name, checkValue}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/radio/Radio.stories.js
+++ b/src/components/inputs/radio/Radio.stories.js
@@ -1,6 +1,7 @@
 import ZoaRadio from './Radio.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="radio"

--- a/src/components/inputs/slider/RangeSlider.stories.js
+++ b/src/components/inputs/slider/RangeSlider.stories.js
@@ -1,6 +1,7 @@
 import ZoaRangeSlider from './RangeSlider.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="range-slider"

--- a/src/components/inputs/slider/RangeSlider.stories.js
+++ b/src/components/inputs/slider/RangeSlider.stories.js
@@ -2,6 +2,19 @@ import ZoaRangeSlider from './RangeSlider.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="range-slider"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, min, max, step, labelsRight,
+                     labelUpper, labelLower}"
+/>
+`;
+
 const meta = {
   component: ZoaRangeSlider,
   title: 'Components/Inputs/Slider/Range',
@@ -16,6 +29,9 @@ const meta = {
       description: {
         component:
           'A component with two sliders representing a lower and upper value. Returns the values as an array.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -44,18 +60,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="range-slider"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, min, max, step, labelsRight,
-                           labelUpper, labelLower}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/slider/Slider.stories.js
+++ b/src/components/inputs/slider/Slider.stories.js
@@ -2,6 +2,20 @@ import ZoaSlider from './Slider.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="slider"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, min, max, step,
+                     placeholderPosition, validMin, validMax,
+                     activeTrackRight, valueLabelPosition}"
+/>
+`;
+
 const meta = {
   component: ZoaSlider,
   title: 'Components/Inputs/Slider/Single',
@@ -19,6 +33,9 @@ const meta = {
     docs: {
       description: {
         component: 'A slider component, returning a single value.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -49,19 +66,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="slider"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, min, max, step,
-                           placeholderPosition, validMin, validMax,
-                           activeTrackRight, valueLabelPosition}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/slider/Slider.stories.js
+++ b/src/components/inputs/slider/Slider.stories.js
@@ -1,6 +1,7 @@
 import ZoaSlider from './Slider.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="slider"

--- a/src/components/inputs/stories.js
+++ b/src/components/inputs/stories.js
@@ -63,9 +63,3 @@ export const argTypes = {
     },
   },
 };
-
-export function renderSetup(args) {
-  args['rootClass'] = args.class;
-  delete args.class;
-  return args;
-}

--- a/src/components/inputs/textbox/AutocompleteTextbox.stories.js
+++ b/src/components/inputs/textbox/AutocompleteTextbox.stories.js
@@ -1,6 +1,7 @@
 import ZoaAutocompleteTextbox from './AutocompleteTextbox.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="autocomplete-textbox"

--- a/src/components/inputs/textbox/AutocompleteTextbox.stories.js
+++ b/src/components/inputs/textbox/AutocompleteTextbox.stories.js
@@ -2,6 +2,18 @@ import ZoaAutocompleteTextbox from './AutocompleteTextbox.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="autocomplete-textbox"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder, options, enableSearch}"
+/>
+`;
+
 const meta = {
   component: ZoaAutocompleteTextbox,
   title: 'Components/Inputs/Textbox/Autocomplete',
@@ -11,6 +23,9 @@ const meta = {
       description: {
         component:
           'A textbox with dropdown options. The text entered into the box is the returned value; options are supplied from outside of the component, and users can choose whether or not to click them.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -39,17 +54,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="autocomplete-textbox"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder, options, enableSearch}"
-      />
-        `,
+    template,
   }),
 };
 

--- a/src/components/inputs/textbox/Textbox.stories.js
+++ b/src/components/inputs/textbox/Textbox.stories.js
@@ -2,6 +2,18 @@ import ZoaTextbox from './Textbox.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes, renderSetup } from '../stories.js';
 
+const template = `
+<zoa-input zoa-type="textbox"
+           :class="rootClass"
+           :label="label"
+           :label-position="labelPosition"
+           :help="help"
+           :help-position="helpPosition"
+           :disabled="disabled"
+           :options="{delay, placeholder}"
+/>
+`;
+
 const meta = {
   component: ZoaTextbox,
   title: 'Components/Inputs/Textbox/Simple',
@@ -10,6 +22,9 @@ const meta = {
     docs: {
       description: {
         component: 'A one-line textbox.',
+      },
+      source: {
+        code: template,
       },
     },
   },
@@ -33,17 +48,7 @@ const Base = {
     setup() {
       return renderSetup(args);
     },
-    template: `
-      <zoa-input zoa-type="textbox"
-                 :class="rootClass"
-                 :label="label"
-                 :label-position="labelPosition"
-                 :help="help"
-                 :help-position="helpPosition"
-                 :disabled="disabled"
-                 :options="{delay, placeholder}"
-      />
-    `,
+    template,
   }),
 };
 

--- a/src/components/inputs/textbox/Textbox.stories.js
+++ b/src/components/inputs/textbox/Textbox.stories.js
@@ -1,6 +1,7 @@
 import ZoaTextbox from './Textbox.vue';
 import { ZoaInput } from '../../index.js';
-import { argTypes, renderSetup } from '../stories.js';
+import { argTypes } from '../stories.js';
+import { renderSetup } from '../../utils/stories.js';
 
 const template = `
 <zoa-input zoa-type="textbox"

--- a/src/components/utils/stories.js
+++ b/src/components/utils/stories.js
@@ -3,3 +3,11 @@ export function renderSetup(args) {
   delete args.class;
   return args;
 }
+
+export function htmlArgs(argsObj) {
+  // convenience function; just transforms the input args into a string of
+  // HTML-like parameters, e.g. {'kind': 'info'} becomes 'kind="info"'
+  return Object.entries(argsObj)
+    .map((a) => a[0] + '=' + '"' + a[1] + '"')
+    .join(' ');
+}

--- a/src/components/utils/stories.js
+++ b/src/components/utils/stories.js
@@ -1,0 +1,5 @@
+export function renderSetup(args) {
+  args['rootClass'] = args.class;
+  delete args.class;
+  return args;
+}


### PR DESCRIPTION
Different versions of storybook seem to regularly change how code examples/snippets are generated (perhaps especially for anything that isn't React). The latest update broke these examples entirely for zoa.

This PR refactors storybook files to use explicitly specified code examples. These are still functional code, so they are declared as separate variables so they can be used as both the `template` (the code used to render the example component) and the source code example.