### PR TITLE
Searching/event fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@storybook/vue3": "^8.4.7",
         "@storybook/vue3-vite": "^8.4.7",
         "@vitejs/plugin-vue": "^5.2.1",
+        "lorem-ipsum": "^2.0.8",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rollup-plugin-visualizer": "^5.14.0",
@@ -2701,6 +2702,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
     "node_modules/constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -3702,6 +3712,22 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lorem-ipsum": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
+      "integrity": "sha512-5RIwHuCb979RASgCJH0VKERn9cQo/+NcAi2BMe9ddj+gp7hujl6BI+qdOG4nVsLDpwWEJwTVYXNKP6BGgbcoGA==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^9.3.0"
+      },
+      "bin": {
+        "lorem-ipsum": "dist/bin/lorem-ipsum.bin.js"
+      },
+      "engines": {
+        "node": ">= 8.x",
+        "npm": ">= 5.x"
       }
     },
     "node_modules/loupe": {
@@ -6696,6 +6722,12 @@
         }
       }
     },
+    "commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true
+    },
     "constantinople": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
@@ -7375,6 +7407,15 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lorem-ipsum": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/lorem-ipsum/-/lorem-ipsum-2.0.8.tgz",
+      "integrity": "sha512-5RIwHuCb979RASgCJH0VKERn9cQo/+NcAi2BMe9ddj+gp7hujl6BI+qdOG4nVsLDpwWEJwTVYXNKP6BGgbcoGA==",
+      "dev": true,
+      "requires": {
+        "commander": "^9.3.0"
       }
     },
     "loupe": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@storybook/vue3": "^8.4.7",
     "@storybook/vue3-vite": "^8.4.7",
     "@vitejs/plugin-vue": "^5.2.1",
+    "lorem-ipsum": "^2.0.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rollup-plugin-visualizer": "^5.14.0",

--- a/src/components/inputs/Input.vue
+++ b/src/components/inputs/Input.vue
@@ -186,6 +186,10 @@ const emit = defineEmits([
    * Search event (emitted by some child inputs).
    */
   'search',
+  /**
+   * Item selection event (emitted by some child inputs).
+   */
+  'selected',
 ]);
 const { value } = useChangeEmits(emit, props);
 

--- a/src/components/inputs/Input.vue
+++ b/src/components/inputs/Input.vue
@@ -24,6 +24,7 @@
           v-bind="options"
           v-model="value"
           ref="inputComponent"
+          @zoa-event="handleCustomEvent"
           v-else
         />
       </fieldset>
@@ -41,6 +42,7 @@
       <zoa-input-component
         v-bind="options"
         v-model="value"
+        @zoa-event="handleCustomEvent"
         ref="inputComponent"
       />
     </template>
@@ -180,8 +182,18 @@ const emit = defineEmits([
    * @ignore
    */
   'update:modelValue',
+  /**
+   * Search event (emitted by some child inputs).
+   */
+  'search',
 ]);
 const { value } = useChangeEmits(emit, props);
+
+function handleCustomEvent(eventName, ...args) {
+  // Emit "custom" (non-standard, i.e. not "change" or "update:modelValue")
+  // events emitted by child input components.
+  emit(eventName, ...args);
+}
 
 const rootContainer = ref(null);
 

--- a/src/components/inputs/common.js
+++ b/src/components/inputs/common.js
@@ -47,5 +47,15 @@ export function useChangeEmits(emit, props) {
     },
   });
 
-  return { emitChange, valueChanged, value };
+  function zoaEvent(eventName, ...args) {
+    /**
+     * Emit an event both as itself and as a generic 'zoaEvent', to be captured
+     * by the ZoaInput wrapper and re-emitted. Any event emitted through this
+     * function should also be added to the list of emits in ZoaInput.
+     */
+    emit(eventName, ...args);
+    emit('zoaEvent', eventName, ...args);
+  }
+
+  return { emitChange, valueChanged, value, zoaEvent };
 }

--- a/src/components/inputs/dropdown/Dropdown.vue
+++ b/src/components/inputs/dropdown/Dropdown.vue
@@ -53,6 +53,7 @@ const props = defineProps({
    */
   options: {
     type: Array,
+    required: true,
   },
 });
 

--- a/src/components/inputs/dropdown/DropdownSearch.vue
+++ b/src/components/inputs/dropdown/DropdownSearch.vue
@@ -149,19 +149,20 @@ const emit = defineEmits([
 const { value } = useChangeEmits(emit, props);
 
 // SEARCH
-const _search = ref(null);
+// to show to the user; should be updated immediately
+const displaySearch = ref(null);
+// to pass to the internal search function; update is debounced
+const activeSearch = ref(null);
 const emitSearch = debounce((searchTerm) => {
+  activeSearch.value = searchTerm;
   emit('search', searchTerm);
-}, props.searchDelay);
-const updateSearch = debounce((searchTerm) => {
-  _search.value = searchTerm;
 }, props.searchDelay);
 const search = computed({
   get() {
-    return _search.value;
+    return displaySearch.value;
   },
   set(searchTerm) {
-    updateSearch(searchTerm);
+    displaySearch.value = searchTerm;
     emitSearch(searchTerm);
   },
 });
@@ -185,8 +186,8 @@ const unfilteredOptions = computed(() => {
 });
 
 const dropdownOptions = computed(() => {
-  const doSearch = props.enableSearch && search.value;
-  const searchString = doSearch ? search.value.toLowerCase() : null;
+  const doSearch = props.enableSearch && activeSearch.value;
+  const searchString = doSearch ? activeSearch.value.toLowerCase() : null;
   const checkMatch = (txt) => {
     return txt
       ? [...fuzzySearch(searchString, txt.toLowerCase(), 1)].length > 0

--- a/src/components/inputs/dropdown/DropdownSearch.vue
+++ b/src/components/inputs/dropdown/DropdownSearch.vue
@@ -100,6 +100,7 @@ const props = defineProps({
    */
   options: {
     type: Array,
+    required: true,
   },
   /**
    * Debounce delay for the `search` event, in ms.

--- a/src/components/inputs/dropdown/DropdownSearch.vue
+++ b/src/components/inputs/dropdown/DropdownSearch.vue
@@ -141,12 +141,16 @@ const emit = defineEmits([
    */
   'update:modelValue',
   /**
+   * @ignore Custom events must be emitted through the zoaEvent function.
+   */
+  'zoaEvent',
+  /**
    * Emitted when the search value changes; debounced if the searchDelay prop is > 0.
    * @arg {string} searchTerm the search term
    */
   'search',
 ]);
-const { value } = useChangeEmits(emit, props);
+const { value, zoaEvent } = useChangeEmits(emit, props);
 
 // SEARCH
 // to show to the user; should be updated immediately
@@ -155,7 +159,7 @@ const displaySearch = ref(null);
 const activeSearch = ref(null);
 const emitSearch = debounce((searchTerm) => {
   activeSearch.value = searchTerm;
-  emit('search', searchTerm);
+  zoaEvent('search', searchTerm);
 }, props.searchDelay);
 const search = computed({
   get() {

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -98,6 +98,7 @@ const manyArgs = {
   itemName: 'datum',
   itemNamePlural: 'data',
   enableSearch: true,
+  searchDelay: 200,
 };
 export const Many = {
   ...Base,
@@ -110,7 +111,7 @@ export const Many = {
            label="${manyArgs.label}"
            label-position="${manyArgs.labelPosition}"
            help="${manyArgs.help}"
-           :options="{options, itemName: '${manyArgs.itemName}', itemNamePlural: '${manyArgs.itemNamePlural}', enableSearch: ${manyArgs.enableSearch}}"
+           :options="{options, itemName: '${manyArgs.itemName}', itemNamePlural: '${manyArgs.itemNamePlural}', enableSearch: ${manyArgs.enableSearch}, searchDelay: ${manyArgs.searchDelay}}"
 />
         `,
       },

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -1,8 +1,8 @@
 import ZoaMultiselect from './Multiselect.vue';
-import { nanoid } from 'nanoid';
 import { ZoaInput } from '../../index.js';
 import { argTypes } from '../stories.js';
 import { renderSetup } from '../../utils/stories.js';
+import { loremIpsum } from 'lorem-ipsum';
 
 const template = `
 <zoa-input zoa-type="multiselect"
@@ -83,7 +83,11 @@ const manyArgs = {
   help: 'An example with a lot of randomly generated options and groups.',
   options: [...Array(300).keys()].map((i) => {
     let opt = {
-      value: nanoid(Math.ceil(Math.random() * 100)),
+      value: loremIpsum({
+        count: Math.ceil(Math.random() * 20),
+        units: 'words',
+        suffix: '',
+      }),
     };
     const group = groups[Math.floor(Math.random() * groups.length)];
     if (group !== 'root') {

--- a/src/components/inputs/dropdown/Multiselect.vue
+++ b/src/components/inputs/dropdown/Multiselect.vue
@@ -48,7 +48,7 @@
           title="Select results"
           :class="[$style.selectAll, $style.listItem, $style.option]"
           :style="{ height: `${itemHeight}px` }"
-          v-if="!!_search"
+          v-if="!!search"
         >
           <zoa-input
             zoa-type="checkbox"
@@ -197,19 +197,20 @@ if (!Array.isArray(value)) {
 }
 
 // SEARCH
-const _search = ref(null);
+// to show to the user; should be updated immediately
+const displaySearch = ref(null);
+// to pass to the internal search function; update is debounced
+const activeSearch = ref(null);
 const emitSearch = debounce((searchTerm) => {
+  activeSearch.value = searchTerm;
   emit('search', searchTerm);
-}, props.searchDelay);
-const updateSearch = debounce((searchTerm) => {
-  _search.value = searchTerm;
 }, props.searchDelay);
 const search = computed({
   get() {
-    return _search.value;
+    return displaySearch.value;
   },
   set(searchTerm) {
-    updateSearch(searchTerm);
+    displaySearch.value = searchTerm;
     emitSearch(searchTerm);
   },
 });
@@ -269,8 +270,8 @@ const unfilteredOptions = computed(() => {
 });
 
 const dropdownOptions = computed(() => {
-  const doSearch = props.enableSearch && search.value;
-  const searchString = doSearch ? search.value.toLowerCase() : null;
+  const doSearch = props.enableSearch && activeSearch.value;
+  const searchString = doSearch ? activeSearch.value.toLowerCase() : null;
   const checkMatch = (txt) => {
     return txt
       ? [...fuzzySearch(searchString, txt.toLowerCase(), 1)].length > 0

--- a/src/components/inputs/dropdown/Multiselect.vue
+++ b/src/components/inputs/dropdown/Multiselect.vue
@@ -184,12 +184,16 @@ const emit = defineEmits([
    */
   'update:modelValue',
   /**
+   * @ignore Custom events must be emitted through the zoaEvent function.
+   */
+  'zoaEvent',
+  /**
    * Emitted when the search value changes; debounced if the searchDelay prop is > 0.
    * @arg {string} searchTerm the search term
    */
   'search',
 ]);
-const { value } = useChangeEmits(emit, props);
+const { value, zoaEvent } = useChangeEmits(emit, props);
 if (!Array.isArray(value)) {
   // needs to be initialised as an array or the checkboxes will all select as
   // one, but returning an empty array as the default prop breaks reactivity
@@ -203,7 +207,7 @@ const displaySearch = ref(null);
 const activeSearch = ref(null);
 const emitSearch = debounce((searchTerm) => {
   activeSearch.value = searchTerm;
-  emit('search', searchTerm);
+  zoaEvent('search', searchTerm);
 }, props.searchDelay);
 const search = computed({
   get() {

--- a/src/components/inputs/dropdown/Multiselect.vue
+++ b/src/components/inputs/dropdown/Multiselect.vue
@@ -129,6 +129,7 @@ const props = defineProps({
    */
   options: {
     type: Array,
+    required: true,
   },
   /**
    * The string used to describe the items being selected, in singular form e.g. "resource", "genus".

--- a/src/components/inputs/stories.js
+++ b/src/components/inputs/stories.js
@@ -4,6 +4,11 @@ export const argTypes = {
       disable: true,
     },
   },
+  zoaEvent: {
+    table: {
+      disable: true,
+    },
+  },
   class: {
     control: 'text',
     description:

--- a/src/components/inputs/textbox/AutocompleteTextbox.stories.js
+++ b/src/components/inputs/textbox/AutocompleteTextbox.stories.js
@@ -2,6 +2,7 @@ import ZoaAutocompleteTextbox from './AutocompleteTextbox.vue';
 import { ZoaInput } from '../../index.js';
 import { argTypes } from '../stories.js';
 import { renderSetup } from '../../utils/stories.js';
+import { loremIpsum } from 'lorem-ipsum';
 
 const template = `
 <zoa-input zoa-type="autocomplete-textbox"
@@ -61,4 +62,36 @@ const Base = {
 
 export const Default = {
   ...Base,
+};
+
+const manyArgs = {
+  label: 'Many Options',
+  labelPosition: 'above',
+  help: 'An example with a lot of randomly generated options.',
+  options: [...Array(300).keys()].map((i) => {
+    return loremIpsum({
+      count: Math.ceil(Math.random() * 20),
+      units: 'words',
+      suffix: '',
+    });
+  }),
+  enableSearch: true,
+};
+export const Many = {
+  ...Base,
+  args: manyArgs,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<zoa-input zoa-type="autocomplete-textbox"
+           label="${manyArgs.label}"
+           label-position="${manyArgs.labelPosition}"
+           help="${manyArgs.help}"
+           :options="{options, enableSearch: ${manyArgs.enableSearch}}"
+/>
+        `,
+      },
+    },
+  },
 };

--- a/src/components/inputs/textbox/AutocompleteTextbox.vue
+++ b/src/components/inputs/textbox/AutocompleteTextbox.vue
@@ -71,6 +71,7 @@ const props = defineProps({
    */
   options: {
     type: Array,
+    required: true,
   },
   /**
    * Debounce delay for the `search` event, in ms.

--- a/src/components/inputs/textbox/AutocompleteTextbox.vue
+++ b/src/components/inputs/textbox/AutocompleteTextbox.vue
@@ -105,18 +105,22 @@ const emit = defineEmits([
    */
   'update:modelValue',
   /**
+   * @ignore Custom events must be emitted through the zoaEvent function.
+   */
+  'zoaEvent',
+  /**
    * Emitted when the search value changes; debounced if the searchDelay prop is > 0.
    * @arg {string} searchTerm the search term
    */
   'search',
 ]);
-const { value, valueChanged } = useChangeEmits(emit, props);
+const { value, valueChanged, zoaEvent } = useChangeEmits(emit, props);
 // The value and the search term are the same, but we don't want to run the
 // search function as often as we update the value.
 const search = ref(null);
 const emitSearch = debounce((searchTerm) => {
   search.value = searchTerm;
-  emit('search', searchTerm);
+  zoaEvent('search', searchTerm);
 }, props.searchDelay);
 value.setter = function (newValue) {
   valueChanged(newValue);

--- a/src/components/inputs/textbox/AutocompleteTextbox.vue
+++ b/src/components/inputs/textbox/AutocompleteTextbox.vue
@@ -113,6 +113,11 @@ const emit = defineEmits([
    * @arg {string} searchTerm the search term
    */
   'search',
+  /**
+   * Emitted when a value is selected from the dropdown.
+   * @arg {string} selected the selected value
+   */
+  'selected',
 ]);
 const { value, valueChanged, zoaEvent } = useChangeEmits(emit, props);
 // The value and the search term are the same, but we don't want to run the
@@ -241,6 +246,7 @@ onKeyStroke('Enter', () => {
 
 function setOption(text) {
   value.value = text;
+  zoaEvent('selected', text);
   unfocus();
 }
 </script>

--- a/src/components/inputs/textbox/AutocompleteTextbox.vue
+++ b/src/components/inputs/textbox/AutocompleteTextbox.vue
@@ -239,6 +239,7 @@ function setOption(text) {
   font-size: 0.9em;
   max-height: 12em;
   overflow-y: auto;
+  z-index: 100;
 
   & > ul {
     padding: 0;


### PR DESCRIPTION
This mostly contains fixes for inputs that involve searching (i.e. autocomplete, searchable dropdown, multiselect), but the event fix _could_ apply to any input (it just doesn't at the moment).

Major fixes:

1. Text being actively entered by the user cannot be updated via a debounced function, especially if that text is directly passed to a search function. When the search function completes, the text is reset to whatever it was when the search started, ignoring anything else the user has typed since then. Fixed by keeping the display text and the search text separate, and by always updating the display text immediately.
2. "custom" events (i.e. anything other than `change` or `update:modelValue`, which are standard on every input) were not being emitted from the parent (`ZoaInput`). Custom events are now emitted through the `zoaEvent()` function, which emits both the original event and one named `zoaEvent`, with the original event name as the first argument. `zoaEvent` emits are captured by the parent and re-emitted as originally intended.