### PR TITLE
Rename options prop to config

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -5,6 +5,7 @@
     "tag_format": "v$version",
     "update_changelog_on_bump": true,
     "changelog_incremental": true,
-    "version_provider": "npm"
+    "version_provider": "npm",
+    "major_version_zero": true
   }
 }

--- a/src/components/inputs/Input.vue
+++ b/src/components/inputs/Input.vue
@@ -21,7 +21,7 @@
           <slot />
         </div>
         <zoa-input-component
-          v-bind="options"
+          v-bind="config"
           v-model="value"
           ref="inputComponent"
           @zoa-event="handleCustomEvent"
@@ -40,7 +40,7 @@
       />
       <zoa-help v-if="help" :text="help" :position="helpPosition" />
       <zoa-input-component
-        v-bind="options"
+        v-bind="config"
         v-model="value"
         @zoa-event="handleCustomEvent"
         ref="inputComponent"
@@ -98,7 +98,7 @@ const props = defineProps({
   /**
    * Parameters passed to the input.
    */
-  options: {
+  config: {
     type: Object,
     default: () => {
       return {};
@@ -163,8 +163,8 @@ const rootClassKeys = computed(() => {
   }
   if (zoaInput.value.wrapperProps) {
     zoaInput.value.wrapperProps.forEach((p) => {
-      if (props.options[p] != null) {
-        _keys.push(`rootWrapper-${p}--${props.options[p]}`);
+      if (props.config[p] != null) {
+        _keys.push(`rootWrapper-${p}--${props.config[p]}`);
       }
     });
   }

--- a/src/components/inputs/checkbox/Checkbox.stories.js
+++ b/src/components/inputs/checkbox/Checkbox.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, name, checkValue}"
+           :config="{delay, name, checkValue}"
 />
 `;
 

--- a/src/components/inputs/date/DateAmbiguous.stories.js
+++ b/src/components/inputs/date/DateAmbiguous.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, min, max}"
+           :config="{delay, placeholder, min, max}"
 />
 `;
 

--- a/src/components/inputs/date/DateAmbiguous.vue
+++ b/src/components/inputs/date/DateAmbiguous.vue
@@ -30,7 +30,7 @@
             zoa-type="number"
             label="millenium"
             label-position="none"
-            :options="{ placeholder: 0, min: 0, max: 9 }"
+            :config="{ placeholder: 0, min: 0, max: 9 }"
             v-model="yearParts.millenium"
             ref="yrM"
           />
@@ -38,7 +38,7 @@
             zoa-type="number"
             label="century"
             label-position="none"
-            :options="{ placeholder: 0, min: 0, max: 9 }"
+            :config="{ placeholder: 0, min: 0, max: 9 }"
             v-model="yearParts.century"
             ref="yrC"
           />
@@ -46,7 +46,7 @@
             zoa-type="number"
             label="decade"
             label-position="none"
-            :options="{ placeholder: 0, min: 0, max: 9 }"
+            :config="{ placeholder: 0, min: 0, max: 9 }"
             v-model="yearParts.decade"
             ref="yrD"
           />
@@ -54,7 +54,7 @@
             zoa-type="number"
             label="year"
             label-position="none"
-            :options="{ placeholder: 0, min: 0, max: 9 }"
+            :config="{ placeholder: 0, min: 0, max: 9 }"
             v-model="yearParts.year"
             ref="yrY"
           />
@@ -73,7 +73,7 @@
         <zoa-input
           zoa-type="number"
           label="month"
-          :options="{ placeholder: 1, min: 1, max: 12 }"
+          :config="{ placeholder: 1, min: 1, max: 12 }"
           v-model="month"
         />
         <div :class="$style.monthGrid" tabindex="0" ref="monthBtns">
@@ -90,7 +90,7 @@
         <zoa-input
           zoa-type="number"
           label="day"
-          :options="{ placeholder: 1, min: 1, max: monthDays }"
+          :config="{ placeholder: 1, min: 1, max: monthDays }"
           v-model="day"
         />
         <div :class="$style.dayGrid" tabindex="0" ref="dayBtns">

--- a/src/components/inputs/date/DateSimple.stories.js
+++ b/src/components/inputs/date/DateSimple.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, min, max, step}"
+           :config="{delay, placeholder, min, max, step}"
 />
 `;
 

--- a/src/components/inputs/dropdown/Dropdown.stories.js
+++ b/src/components/inputs/dropdown/Dropdown.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, options}"
+           :config="{delay, placeholder, options}"
 />
 `;
 

--- a/src/components/inputs/dropdown/DropdownSearch.stories.js
+++ b/src/components/inputs/dropdown/DropdownSearch.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, options, searchDelay, enableSearch, itemHeight}"
+           :config="{delay, placeholder, options, searchDelay, enableSearch, itemHeight}"
 />
 `;
 

--- a/src/components/inputs/dropdown/DropdownSearch.vue
+++ b/src/components/inputs/dropdown/DropdownSearch.vue
@@ -44,7 +44,7 @@
               zoa-type="radio"
               :label="item.label"
               label-position="right"
-              :options="{ checkValue: item.value, name: subId('radio') }"
+              :config="{ checkValue: item.value, name: subId('radio') }"
               v-model="value"
               v-if="item.ix >= lowerVisible && item.ix <= upperVisible"
               @change="unfocus"

--- a/src/components/inputs/dropdown/Multiselect.stories.js
+++ b/src/components/inputs/dropdown/Multiselect.stories.js
@@ -12,7 +12,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, options, itemName, itemNamePlural, searchDelay, enableSearch, itemHeight}"
+           :config="{delay, placeholder, options, itemName, itemNamePlural, searchDelay, enableSearch, itemHeight}"
 />
 `;
 
@@ -111,7 +111,7 @@ export const Many = {
            label="${manyArgs.label}"
            label-position="${manyArgs.labelPosition}"
            help="${manyArgs.help}"
-           :options="{options, itemName: '${manyArgs.itemName}', itemNamePlural: '${manyArgs.itemNamePlural}', enableSearch: ${manyArgs.enableSearch}, searchDelay: ${manyArgs.searchDelay}}"
+           :config="{options, itemName: '${manyArgs.itemName}', itemNamePlural: '${manyArgs.itemNamePlural}', enableSearch: ${manyArgs.enableSearch}, searchDelay: ${manyArgs.searchDelay}}"
 />
         `,
       },

--- a/src/components/inputs/dropdown/Multiselect.vue
+++ b/src/components/inputs/dropdown/Multiselect.vue
@@ -74,7 +74,7 @@
               zoa-type="checkbox"
               :label="item.label"
               label-position="right"
-              :options="{ checkValue: item.value, name: subId('checkboxes') }"
+              :config="{ checkValue: item.value, name: subId('checkboxes') }"
               v-model="value"
               v-if="item.ix >= lowerVisible && item.ix <= upperVisible"
             />

--- a/src/components/inputs/empty/Empty.stories.js
+++ b/src/components/inputs/empty/Empty.stories.js
@@ -26,7 +26,7 @@ const meta = {
         disable: true,
       },
     },
-    options: {
+    config: {
       table: {
         disable: true,
       },

--- a/src/components/inputs/number/Number.stories.js
+++ b/src/components/inputs/number/Number.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, min, max, step}"
+           :config="{delay, placeholder, min, max, step}"
 />
 `;
 

--- a/src/components/inputs/radio/Radio.stories.js
+++ b/src/components/inputs/radio/Radio.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, name, checkValue}"
+           :config="{delay, name, checkValue}"
 />
 `;
 

--- a/src/components/inputs/slider/RangeSlider.stories.js
+++ b/src/components/inputs/slider/RangeSlider.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, min, max, step, labelsRight,
+           :config="{delay, placeholder, min, max, step, labelsRight,
                      labelUpper, labelLower}"
 />
 `;

--- a/src/components/inputs/slider/RangeSlider.vue
+++ b/src/components/inputs/slider/RangeSlider.vue
@@ -8,7 +8,7 @@
       zoa-type="slider"
       :label="labelLower"
       :label-position="labelsRight ? 'right' : 'left'"
-      :options="{
+      :config="{
         min,
         max,
         step,
@@ -24,7 +24,7 @@
       zoa-type="slider"
       :label="labelUpper"
       :label-position="labelsRight ? 'right' : 'left'"
-      :options="{
+      :config="{
         min,
         max,
         step,

--- a/src/components/inputs/slider/Slider.stories.js
+++ b/src/components/inputs/slider/Slider.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, min, max, step,
+           :config="{delay, placeholder, min, max, step,
                      placeholderPosition, validMin, validMax,
                      activeTrackRight, valueLabelPosition}"
 />

--- a/src/components/inputs/textbox/AutocompleteTextbox.stories.js
+++ b/src/components/inputs/textbox/AutocompleteTextbox.stories.js
@@ -12,7 +12,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder, options, enableSearch}"
+           :config="{delay, placeholder, options, enableSearch}"
 />
 `;
 
@@ -88,7 +88,7 @@ export const Many = {
            label="${manyArgs.label}"
            label-position="${manyArgs.labelPosition}"
            help="${manyArgs.help}"
-           :options="{options, enableSearch: ${manyArgs.enableSearch}}"
+           :config="{options, enableSearch: ${manyArgs.enableSearch}}"
 />
         `,
       },

--- a/src/components/inputs/textbox/Textbox.stories.js
+++ b/src/components/inputs/textbox/Textbox.stories.js
@@ -11,7 +11,7 @@ const template = `
            :help="help"
            :help-position="helpPosition"
            :disabled="disabled"
-           :options="{delay, placeholder}"
+           :config="{delay, placeholder}"
 />
 `;
 


### PR DESCRIPTION
Renames the `options` prop in the input wrapper (`ZoaInput`) to `config` to avoid confusion with the `options` prop in some child components.

Previous usage of the multiselect component:
```vue
<zoa-input zoa-type="multiselect" :options="{options: ['a', 'b', 'c']}"/>
```

Now:
```vue
<zoa-input zoa-type="multiselect" :config="{options: ['a', 'b', 'c']}"/>
```

This PR also adds the `major_version_zero` flag to the commitizen config, which will keep the version in alpha (i.e. v0) even with breaking changes. When zoa moves out of alpha, this flag will need to be removed.