### PR TITLE
Patch release 2025-02-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Inputs (other than the button and toggle button) are used via the `<zoa-input>` 
   <zoa-input
     zoa-type="checkbox"
     label="Checkbox"
-    :options="{ name: 'chkbox', delay: '200' }"
+    :config="{ name: 'chkbox', delay: '200' }"
   />
   <zoa-input
     zoa-type="textbox"
     label="Textbox"
-    :options="{ placeholder: 'this is a placeholder' }"
+    :config="{ placeholder: 'this is a placeholder' }"
   />
 </template>
 


### PR DESCRIPTION
Missed renaming the `options` prop in the two `<zoa-input>` examples in the readme.