### PR TITLE
Prereleases

### DIFF
--- a/.cz.json
+++ b/.cz.json
@@ -6,6 +6,7 @@
     "update_changelog_on_bump": true,
     "changelog_incremental": true,
     "version_provider": "npm",
-    "major_version_zero": true
+    "major_version_zero": true,
+    "changelog_merge_prerelease": true
   }
 }

--- a/.cz.json
+++ b/.cz.json
@@ -2,7 +2,6 @@
   "commitizen": {
     "name": "cz_nhm",
     "tag_format": "v$version",
-    "update_changelog_on_bump": true,
     "changelog_incremental": true,
     "version_provider": "npm",
     "major_version_zero": true,

--- a/.cz.json
+++ b/.cz.json
@@ -1,7 +1,6 @@
 {
   "commitizen": {
     "name": "cz_nhm",
-    "version": "0.10.1",
     "tag_format": "v$version",
     "update_changelog_on_bump": true,
     "changelog_incremental": true,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,7 @@
 name: Build dist (dev/patch)
 
 on:
-  pull_request:
-    types:
-      - closed
+  push:
     branches:
       - dev
       - patch
@@ -12,7 +10,7 @@ jobs:
   build-dist:
     name: Build dist package
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: "!startsWith(github.event.head_commit.message, 'chore(dist):')"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -28,4 +26,4 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: dist
-          message: 'chore: build dist package'
+          message: 'chore(dist): build dist package'

--- a/.github/workflows/bump-prerelease.yml
+++ b/.github/workflows/bump-prerelease.yml
@@ -30,5 +30,6 @@ jobs:
           body_path: 'CURRENT.md'
           tag_name: v${{ env.REVISION }}
           prerelease: true
+          target_commitish: dev
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/bump-prerelease.yml
+++ b/.github/workflows/bump-prerelease.yml
@@ -1,0 +1,34 @@
+name: Bump version (prerelease)
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  bump-and-release:
+    name: Create prerelease
+    runs-on: ubuntu-latest
+    if: "startsWith(github.event.head_commit.message, 'chore(dist):')"
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          fetch-depth: 0
+      - name: Create bump
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          changelog_increment_filename: CURRENT.md
+          extra_requirements: 'cz-nhm'
+          prerelease: alpha
+          changelog: false
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: 'CURRENT.md'
+          tag_name: v${{ env.REVISION }}
+          prerelease: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -6,8 +6,8 @@ on:
       - main
 
 jobs:
-  build-then-bump:
-    name: Build dist package, bump version, create changelog
+  bump-and-release:
+    name: Build, bump, and create main release
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     steps:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -28,7 +28,7 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           add: dist
-          message: 'chore: build dist package'
+          message: 'chore(dist): build dist package'
           push: false
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -36,6 +36,7 @@ jobs:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           changelog_increment_filename: CURRENT.md
           extra_requirements: 'cz-nhm'
+          changelog: true
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -37,7 +37,7 @@ jobs:
           changelog_increment_filename: CURRENT.md
           extra_requirements: 'cz-nhm'
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           body_path: 'CURRENT.md'
           tag_name: v${{ env.REVISION }}

--- a/.github/workflows/npm-publish-prerelease.yml
+++ b/.github/workflows/npm-publish-prerelease.yml
@@ -1,4 +1,4 @@
-name: Upload NPM Package
+name: Upload NPM Package (dev)
 
 on:
   release:
@@ -9,7 +9,7 @@ jobs:
   deploy:
     name: Publish to NPM
     runs-on: ubuntu-latest
-    if: "!github.event.release.prerelease"
+    if: "github.event.release.prerelease"
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -22,6 +22,6 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - name: Publish package
-        run: npm publish
+        run: npm publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR should set up workflows that will create prereleases on the `dev` branch when the dist package is rebuilt, then push that to NPM as a `dev` package.

The major issue with this setup is the changelog: `CHANGELOG.md` is not regenerated for these prereleases, and there is no `DEV-CHANGELOG.md` or similar because there is no option to change the filename in the action. This is not ideal, but it's a workaround for some commitizen bugs (particularly 996, but also kind of 1068) which mean that we can't have prereleases in the main changelog.